### PR TITLE
Add image quality scoring command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,26 @@ seev distance input.jpg comparison.png
 * Distance is a floating point number between 0 and 1
 * Lower distance means images are more similar
 
+### Image Quality
+
+```sh
+seev quality input.jpg
+```
+
+The `quality` command uses Apple Vision to score the aesthetic quality of an image:
+
+```json
+{
+  "input": "input.jpg",
+  "overallScore": 0.72,
+  "isUtility": false
+}
+```
+
+* `overallScore` ranges from `-1` (least desirable) to `1` (most desirable).
+* `isUtility` identifies useful images that may not have memorable or exciting content.
+* Scores are most useful for ranking images or video frames rather than as a universal pass/fail threshold.
+
 ### Image Moderation
 
 `seev nsfw` classifies images as NSFW using ShieldGemma 2 through Ollama. Its policy covers nudity, visible intimate body parts, and erotic presentation. It does not perform text moderation. Images remain on the local machine when using the default local Ollama endpoint.

--- a/Sources/seev/commands/quality.swift
+++ b/Sources/seev/commands/quality.swift
@@ -1,0 +1,28 @@
+import ArgumentParser
+import Vision
+
+@available(macOS 15.0, *)
+struct Quality: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    abstract: "Scores the aesthetic quality of an image."
+  )
+
+  @Argument(help: "The filepath of the input image")
+  var input: String
+
+  mutating func run() throws {
+    let observations: [VNImageAestheticsScoresObservation] = try performRequest(
+      request: VNCalculateImageAestheticsScoresRequest(),
+      inputImagePath: input
+    )
+    guard let quality = observations.first else {
+      throw ValidationError("Vision did not return an image quality score.")
+    }
+
+    printDict([
+      "input": input,
+      "overallScore": quality.overallScore,
+      "isUtility": quality.isUtility,
+    ])
+  }
+}

--- a/Sources/seev/seev.swift
+++ b/Sources/seev/seev.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-let VERSION = "2.1.0"
+let VERSION = "2.2.0"
 
 struct Options: ParsableArguments {
   @Argument(help: "The filepath of the input image")
@@ -25,6 +25,7 @@ struct seev: AsyncParsableCommand {
       Embeddings.self,
       Distance.self,
       Classify.self,
+      Quality.self,
       Poses.self,
       All.self,
       Most.self,


### PR DESCRIPTION
## Summary
- add a quality command returning overallScore and isUtility
- document score semantics and example output
- bump the CLI version to 2.2.0

## Verification
- swift build --configuration release
- release binary version and help checks
- quality scoring succeeded on all 11 repository demo and input images
- missing-image failure returned a nonzero exit status