### PR TITLE
Add representative video frame analysis

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
   name: "seev",
+  platforms: [
+    .macOS("15.0")
+  ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0")
   ],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # seeV
 
-seeV is a macOS command line wrapper around the [Apple Vision framework](https://developer.apple.com/documentation/vision). Its goal is to unlock the functionality of the framework for use in shell scripts and other command line tools. seeV is written in Swift and requires macOS 15 or later.
+seeV is a macOS command line wrapper around the [Apple Vision framework](https://developer.apple.com/documentation/vision). Its goal is to unlock the functionality of the framework for images and videos in shell scripts and other command line tools. seeV is written in Swift and requires macOS 15 or later.
 
 Most seeV operations have no runtime dependencies or network requirements because Vision.framework ships with macOS. The `nsfw` command and the NSFW phase of `all` additionally require [Ollama](https://ollama.com/) and an installed image-capable [ShieldGemma 2](https://huggingface.co/google/shieldgemma-2-4b-it) model. The `most` command never uses Ollama.
 
@@ -104,7 +104,7 @@ seev distance input.jpg comparison.png
 seev quality input.jpg
 ```
 
-The `quality` command uses Apple Vision to score the aesthetic quality of an image:
+The `quality` command uses Apple Vision to score the aesthetic quality of an image or representative video frames:
 
 ```json
 {
@@ -138,12 +138,7 @@ seev nsfw input.jpg
 The result is a boolean policy decision:
 
 ```json
-{
-  "input": "input.jpg",
-  "model": "hf.co/infil00p/shieldgemma-2-4b-it-GGUF:Q4_K_M",
-  "policy": "nsfw",
-  "violation": false
-}
+false
 ```
 
 ShieldGemma is a policy classifier: for each image and policy it answers `Yes` or `No`. It does not return bounding boxes or identify individual body parts. Applications should treat the result as one moderation signal, use a review path for uncertain or high-impact decisions, and evaluate the model against examples that match their own policy.
@@ -186,13 +181,50 @@ The GGUF package above is a [third-party Ollama-compatible conversion](https://h
 seev all input.jpg
 ```
 
-The `all` command runs faces, humans, text, poses, classification, embeddings, SHA-1, and NSFW classification independently. It accepts the same `--ollama-host` option as `nsfw`. A failed operation does not discard successful results; failures are returned in an `errors` object keyed by operation. For example, an unavailable Ollama service produces an `errors.nsfw` message while the Vision results are still returned. The command exits with a failure status only when every operation fails.
+The `all` command runs faces, humans, text, poses, classification, quality, embeddings, SHA-1, and NSFW classification independently. It accepts the same `--ollama-host` option as `nsfw`. A successful NSFW result is returned as a boolean. A failed operation does not discard successful results; failures are returned in an `errors` object keyed by operation. For example, an unavailable Ollama service produces an `errors.nsfw` message while the Vision results are still returned. The command exits with a failure status only when every operation fails.
 
 Use `most` for combined analysis without full-image embeddings, per-face embeddings, or NSFW classification. This keeps the JSON output substantially smaller and does not require Ollama:
 
 ```sh
 seev most input.jpg
 ```
+
+## Video Input
+
+Frame-based commands automatically recognize video files. There is no separate video command:
+
+```sh
+seev faces input.mp4
+seev quality input.mp4 --max-frames 5
+seev nsfw input.mp4
+seev most input.mp4
+```
+
+`faces`, `humans`, `text`, `embeddings`, `classify`, `poses`, `quality`, `nsfw`, `all`, and `most` accept video input. The only video-specific option is `--max-frames`, which defaults to `10` and sets an upper bound on the number of representative frames analyzed.
+
+Video results contain the duration and the actual timestamp of each decoded frame:
+
+```json
+{
+  "input": "input.mp4",
+  "durationSeconds": 93.4,
+  "frames": [
+    {
+      "timestampSeconds": 4.67,
+      "nsfw": false,
+      "faces": []
+    }
+  ]
+}
+```
+
+Frames are sampled from the center of evenly spaced time ranges for broad temporal coverage, avoiding the exact beginning and end of the video. seeV asks AVFoundation for nearby keyframes and scales them to a maximum dimension of 1280 pixels for faster analysis. If a frame cannot be decoded, seeV makes one nearby fallback attempt. The same face, text, or other result remains present in every sampled frame where it is detected; results are not deduplicated across frames.
+
+For images, standalone `nsfw` returns a JSON boolean. For videos, each frame contains an `nsfw` boolean alongside its timestamp. Per-operation failures remain under the frame's `errors` object.
+
+`sha1` hashes a video as one file. `distance` and subject extraction remain image-only. Annotated or cropped image output options such as `-o` and `--cropped` are not supported for video input.
+
+Representative-frame sampling is a fast heuristic, not exhaustive video moderation. Content that appears only between sampled frames may not be detected; increase `--max-frames` when greater coverage is required.
 
 ## Installation
 

--- a/Sources/seev/FrameAnalysis.swift
+++ b/Sources/seev/FrameAnalysis.swift
@@ -1,0 +1,309 @@
+import ArgumentParser
+import CoreGraphics
+import Foundation
+import Vision
+
+struct FaceAnalysisArtifact {
+  let observations: [VNFaceObservation]
+  let embeddingFailureCount: Int
+}
+
+func faceAnalysis(
+  input: AnalysisInput,
+  includeEmbeddings: Bool
+) throws -> FrameAnalysisResult<FaceAnalysisArtifact> {
+  let faces: [VNFaceObservation] = try input.perform(VNDetectFaceRectanglesRequest())
+  var embeddingFailureCount = 0
+  let output = faces.map { face in
+    var result: [String: Any] = [
+      "roll": face.roll ?? 0,
+      "yaw": face.yaw ?? 0,
+      "pitch": face.pitch ?? 0,
+      "boundingBox": boundingBoxDictionary(face.boundingBox),
+      "confidence": face.confidence,
+    ]
+
+    guard includeEmbeddings else {
+      return result
+    }
+
+    do {
+      let faceImage = try input.crop(to: face.boundingBox)
+      let featurePrint: VNFeaturePrintObservation = try firstObservation(
+        request: VNGenerateImageFeaturePrintRequest(),
+        input: .image(faceImage)
+      )
+      result["embedding"] = embeddingArray(featurePrint)
+    } catch {
+      embeddingFailureCount += 1
+    }
+    return result
+  }
+
+  return FrameAnalysisResult(
+    output: ["faces": output],
+    artifact: FaceAnalysisArtifact(
+      observations: faces,
+      embeddingFailureCount: embeddingFailureCount
+    )
+  )
+}
+
+func humanAnalysis(
+  input: AnalysisInput
+) throws -> FrameAnalysisResult<[VNHumanObservation]> {
+  let humans: [VNHumanObservation] = try input.perform(VNDetectHumanRectanglesRequest())
+  return FrameAnalysisResult(
+    output: [
+      "humans": humans.map { human in
+        [
+          "boundingBox": boundingBoxDictionary(human.boundingBox),
+          "confidence": human.confidence,
+        ] as [String: Any]
+      }
+    ],
+    artifact: humans
+  )
+}
+
+func textAnalysis(
+  input: AnalysisInput,
+  customWords: [String] = []
+) throws -> FrameAnalysisResult<[VNRecognizedTextObservation]> {
+  let request = VNRecognizeTextRequest()
+  request.recognitionLevel = .accurate
+  request.usesLanguageCorrection = true
+  request.customWords = customWords
+  let observations: [VNRecognizedTextObservation] = try input.perform(request)
+  return FrameAnalysisResult(
+    output: [
+      "text": observations.map { observation in
+        [
+          "boundingBox": boundingBoxDictionary(observation.boundingBox),
+          "text": observation.topCandidates(1).first?.string ?? "Failed to recognize text",
+          "confidence": observation.confidence,
+        ] as [String: Any]
+      }
+    ],
+    artifact: observations
+  )
+}
+
+func poseAnalysis(
+  input: AnalysisInput
+) throws -> FrameAnalysisResult<[VNHumanBodyPoseObservation]> {
+  let poses: [VNHumanBodyPoseObservation] = try input.perform(VNDetectHumanBodyPoseRequest())
+  return FrameAnalysisResult(
+    output: [
+      "poses": poses.map { pose in
+        [
+          "joints": pose.availableJointNames.compactMap { jointName -> [String: Any]? in
+            guard let point = try? pose.recognizedPoint(jointName) else {
+              return nil
+            }
+            return [
+              "name": jointName.rawValue,
+              "x": point.location.x,
+              "y": point.location.y,
+              "confidence": point.confidence,
+            ]
+          }
+        ]
+      }
+    ],
+    artifact: poses
+  )
+}
+
+func classificationAnalysis(
+  input: AnalysisInput,
+  minimumConfidence: Float,
+  includeIdentifiers: [String]
+) throws -> FrameAnalysisResult<Void> {
+  let classifications: [VNClassificationObservation] = try input.perform(VNClassifyImageRequest())
+  let filtered = classifications.filter { $0.confidence >= minimumConfidence }
+  var output = filtered.map { classification in
+    [
+      "identifier": classification.identifier,
+      "confidence": classification.confidence,
+    ] as [String: Any]
+  }
+  for identifier in includeIdentifiers
+  where !filtered.contains(where: { $0.identifier == identifier }) {
+    output.append([
+      "identifier": identifier,
+      "confidence": classifications.first(where: { $0.identifier == identifier })?.confidence ?? 0,
+    ])
+  }
+  return FrameAnalysisResult(output: ["classifications": output])
+}
+
+func embeddingAnalysis(input: AnalysisInput) throws -> FrameAnalysisResult<Void> {
+  let observation: VNFeaturePrintObservation = try firstObservation(
+    request: VNGenerateImageFeaturePrintRequest(),
+    input: input
+  )
+  return FrameAnalysisResult(output: ["embedding": embeddingArray(observation)])
+}
+
+@available(macOS 15.0, *)
+func qualityAnalysis(input: AnalysisInput) throws -> FrameAnalysisResult<Void> {
+  let observation: VNImageAestheticsScoresObservation = try firstObservation(
+    request: VNCalculateImageAestheticsScoresRequest(),
+    input: input
+  )
+  return FrameAnalysisResult(output: [
+    "overallScore": observation.overallScore,
+    "isUtility": observation.isUtility,
+  ])
+}
+
+@available(macOS 15.0, *)
+func combinedAnalysis(
+  input: AnalysisInput,
+  includeEmbeddings: Bool,
+  nsfwClassifier: ShieldGemmaNSFWClassifier?,
+  nsfwSetupError: String? = nil
+) async throws -> FrameAnalysisResult<Void> {
+  var result: [String: Any] = [:]
+  var errors: [String: String] = [:]
+  var successCount = 0
+
+  func attempt<Artifact>(
+    _ name: String,
+    _ operation: () throws -> FrameAnalysisResult<Artifact>
+  ) -> FrameAnalysisResult<Artifact>? {
+    do {
+      let value = try operation()
+      successCount += 1
+      return value
+    } catch {
+      errors[name] = error.localizedDescription
+      return nil
+    }
+  }
+
+  if let faces = attempt(
+    "faces",
+    {
+      try faceAnalysis(input: input, includeEmbeddings: includeEmbeddings)
+    })
+  {
+    result.merge(faces.output) { _, new in new }
+    if faces.artifact.embeddingFailureCount > 0 {
+      errors["faceEmbeddings"] =
+        "Failed to generate embeddings for \(faces.artifact.embeddingFailureCount) of \(faces.artifact.observations.count) faces."
+    }
+  }
+  if let humans = attempt("humans", { try humanAnalysis(input: input) }) {
+    result.merge(humans.output) { _, new in new }
+  }
+  if let text = attempt("text", { try textAnalysis(input: input) }) {
+    result.merge(text.output) { _, new in new }
+  }
+  if let poses = attempt("poses", { try poseAnalysis(input: input) }) {
+    result.merge(poses.output) { _, new in new }
+  }
+  if let classifications = attempt(
+    "classifications",
+    {
+      try classificationAnalysis(
+        input: input,
+        minimumConfidence: 0.4,
+        includeIdentifiers: []
+      )
+    })
+  {
+    result.merge(classifications.output) { _, new in new }
+  }
+  if let quality = attempt("quality", { try qualityAnalysis(input: input) }) {
+    result["quality"] = quality.output
+  }
+  if includeEmbeddings,
+    let embedding = attempt("embedding", { try embeddingAnalysis(input: input) })
+  {
+    result.merge(embedding.output) { _, new in new }
+  }
+
+  if let nsfwClassifier {
+    do {
+      result["nsfw"] = try await input.isNSFW(using: nsfwClassifier)
+      successCount += 1
+    } catch {
+      errors["nsfw"] = error.localizedDescription
+    }
+  } else if let nsfwSetupError {
+    errors["nsfw"] = nsfwSetupError
+  }
+
+  guard successCount > 0 else {
+    let summary = errors.sorted { $0.key < $1.key }
+      .map { "\($0.key): \($0.value)" }
+      .joined(separator: "; ")
+    throw ValidationError("All operations failed. \(summary)")
+  }
+  if !errors.isEmpty {
+    result["errors"] = errors
+  }
+  return FrameAnalysisResult(output: result)
+}
+
+func addFileHash(to result: inout [String: Any], input: String) {
+  do {
+    result["sha1"] = try hashFile(inputImagePath: input)
+  } catch {
+    var errors = result["errors"] as? [String: String] ?? [:]
+    errors["sha1"] = error.localizedDescription
+    result["errors"] = errors
+  }
+}
+
+@available(macOS 15.0, *)
+func runCombinedMediaAnalysis(
+  input: String,
+  maxFrames: Int,
+  includeEmbeddings: Bool,
+  nsfwClassifier: ShieldGemmaNSFWClassifier? = nil,
+  nsfwSetupError: String? = nil
+) async throws {
+  var result = try await analyzeMedia(
+    input: input,
+    maxFrames: maxFrames,
+    operationName: "combined"
+  ) { analysisInput in
+    try await combinedAnalysis(
+      input: analysisInput,
+      includeEmbeddings: includeEmbeddings,
+      nsfwClassifier: nsfwClassifier,
+      nsfwSetupError: nsfwSetupError
+    )
+  }.output
+  addFileHash(to: &result, input: input)
+  printDict(result)
+}
+
+private func boundingBoxDictionary(_ boundingBox: CGRect) -> [String: CGFloat] {
+  [
+    "x": boundingBox.origin.x,
+    "y": boundingBox.origin.y,
+    "width": boundingBox.width,
+    "height": boundingBox.height,
+  ]
+}
+
+private func embeddingArray(_ observation: VNFeaturePrintObservation) -> [Float] {
+  observation.data.withUnsafeBytes {
+    Array($0.bindMemory(to: Float.self))
+  }
+}
+
+private func firstObservation<T: VNObservation>(
+  request: VNRequest,
+  input: AnalysisInput
+) throws -> T {
+  let observations: [T] = try input.perform(request)
+  guard let observation = observations.first else {
+    throw ValidationError("Vision did not return a result.")
+  }
+  return observation
+}

--- a/Sources/seev/MediaInput.swift
+++ b/Sources/seev/MediaInput.swift
@@ -1,0 +1,236 @@
+import AVFoundation
+import ArgumentParser
+import CoreGraphics
+import Foundation
+import UniformTypeIdentifiers
+import Vision
+
+let defaultMaxFrames = 10
+
+struct VideoFrame {
+  let image: CGImage
+  let timestampSeconds: Double
+}
+
+struct VideoFrames {
+  let durationSeconds: Double
+  let frames: [VideoFrame]
+}
+
+enum AnalysisInput {
+  case url(URL)
+  case image(CGImage)
+
+  func perform<T: VNObservation>(_ request: VNRequest) throws -> [T] {
+    switch self {
+    case .url(let url):
+      let handler = VNImageRequestHandler(url: url)
+      try handler.perform([request])
+    case .image(let image):
+      let handler = VNImageRequestHandler(cgImage: image)
+      try handler.perform([request])
+    }
+    return request.results as? [T] ?? []
+  }
+
+  func crop(to boundingBox: CGRect) throws -> CGImage {
+    switch self {
+    case .url(let url):
+      return try cropImage(inputURL: url, boundingBox: boundingBox)
+    case .image(let image):
+      return try cropImage(input: image, boundingBox: boundingBox)
+    }
+  }
+
+  func isNSFW(using classifier: ShieldGemmaNSFWClassifier) async throws -> Bool {
+    switch self {
+    case .url(let url):
+      return try await classifier.isNSFW(imageAt: url)
+    case .image(let image):
+      return try await classifier.isNSFW(image: image)
+    }
+  }
+}
+
+struct FrameAnalysisResult<Artifact> {
+  let output: [String: Any]
+  let artifact: Artifact
+}
+
+extension FrameAnalysisResult where Artifact == Void {
+  init(output: [String: Any]) {
+    self.init(output: output, artifact: ())
+  }
+}
+
+struct MediaAnalysisResult<Artifact> {
+  var output: [String: Any]
+  let imageArtifact: Artifact?
+}
+
+enum VideoInputError: LocalizedError {
+  case invalidVideo(String)
+  case noUsableFrames
+  case imageOutputUnsupported
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidVideo(let reason):
+      return "Could not read the video: \(reason)"
+    case .noUsableFrames:
+      return "The video did not contain any decodable frames."
+    case .imageOutputUnsupported:
+      return "Image output options are not supported for video inputs."
+    }
+  }
+}
+
+func isVideoInput(_ input: String) -> Bool {
+  let fileExtension = inputImagePathToURL(input).pathExtension
+  guard !fileExtension.isEmpty, let type = UTType(filenameExtension: fileExtension) else {
+    return false
+  }
+  return type.conforms(to: .movie)
+}
+
+@available(macOS 13.0, *)
+func extractVideoFrames(input: String, maxFrames: Int) async throws -> VideoFrames {
+  let asset = AVURLAsset(url: inputImagePathToURL(input))
+  let duration: CMTime
+  let tracks: [AVAssetTrack]
+  do {
+    (duration, tracks) = try await asset.load(.duration, .tracks)
+  } catch {
+    throw VideoInputError.invalidVideo(error.localizedDescription)
+  }
+
+  guard tracks.contains(where: { $0.mediaType == .video }) else {
+    throw VideoInputError.invalidVideo("no video track was found")
+  }
+
+  let durationSeconds = duration.seconds
+  guard durationSeconds.isFinite, durationSeconds > 0 else {
+    throw VideoInputError.invalidVideo("the duration is missing or invalid")
+  }
+
+  let bucketDuration = durationSeconds / Double(maxFrames)
+  let primaryTimes = (0..<maxFrames).map { index in
+    CMTime(
+      seconds: (Double(index) + 0.5) * bucketDuration,
+      preferredTimescale: 600
+    )
+  }
+
+  let generator = AVAssetImageGenerator(asset: asset)
+  generator.appliesPreferredTrackTransform = true
+  generator.maximumSize = CGSize(width: 1280, height: 1280)
+  let tolerance = min(0.5, bucketDuration * 0.2)
+  generator.requestedTimeToleranceBefore = CMTime(seconds: tolerance, preferredTimescale: 600)
+  generator.requestedTimeToleranceAfter = CMTime(seconds: tolerance, preferredTimescale: 600)
+
+  var selected = await generateVideoFrames(at: primaryTimes, using: generator)
+  let missingIndices = selected.indices.filter { selected[$0] == nil }
+  if !missingIndices.isEmpty {
+    let fallbackTimes = missingIndices.map { index in
+      let position = index.isMultiple(of: 2) ? 0.25 : 0.75
+      return CMTime(
+        seconds: (Double(index) + position) * bucketDuration,
+        preferredTimescale: 600
+      )
+    }
+    let fallbacks = await generateVideoFrames(at: fallbackTimes, using: generator)
+    for (fallbackIndex, selectedIndex) in missingIndices.enumerated() {
+      selected[selectedIndex] = fallbacks[fallbackIndex]
+    }
+  }
+
+  let sortedFrames = selected.compactMap { $0 }.sorted {
+    $0.timestampSeconds < $1.timestampSeconds
+  }
+  var uniqueFrames: [VideoFrame] = []
+  for frame in sortedFrames {
+    if let previous = uniqueFrames.last,
+      abs(previous.timestampSeconds - frame.timestampSeconds) < 0.001
+    {
+      continue
+    }
+    uniqueFrames.append(frame)
+  }
+
+  guard !uniqueFrames.isEmpty else {
+    throw VideoInputError.noUsableFrames
+  }
+  return VideoFrames(durationSeconds: durationSeconds, frames: uniqueFrames)
+}
+
+@available(macOS 13.0, *)
+private func generateVideoFrames(
+  at times: [CMTime],
+  using generator: AVAssetImageGenerator
+) async -> [VideoFrame?] {
+  var frames = [VideoFrame?](repeating: nil, count: times.count)
+  for await result in generator.images(for: times) {
+    guard let index = times.firstIndex(where: { CMTimeCompare($0, result.requestedTime) == 0 })
+    else {
+      continue
+    }
+
+    do {
+      let image = try result.image
+      frames[index] = VideoFrame(
+        image: image,
+        timestampSeconds: try result.actualTime.seconds
+      )
+    } catch {
+      continue
+    }
+  }
+  return frames
+}
+
+@available(macOS 13.0, *)
+func analyzeMedia<Artifact>(
+  input: String,
+  maxFrames: Int,
+  operationName: String,
+  analysis: (AnalysisInput) async throws -> FrameAnalysisResult<Artifact>
+) async throws -> MediaAnalysisResult<Artifact> {
+  guard isVideoInput(input) else {
+    let result = try await analysis(.url(inputImagePathToURL(input)))
+    var output: [String: Any] = ["input": input]
+    output.merge(result.output) { _, new in new }
+    return MediaAnalysisResult(
+      output: output,
+      imageArtifact: result.artifact
+    )
+  }
+
+  let video = try await extractVideoFrames(input: input, maxFrames: maxFrames)
+  var results: [[String: Any]] = []
+  var successCount = 0
+
+  for frame in video.frames {
+    var frameResult: [String: Any] = ["timestampSeconds": frame.timestampSeconds]
+    do {
+      let analysisResult = try await analysis(.image(frame.image))
+      frameResult.merge(analysisResult.output) { _, new in new }
+      successCount += 1
+    } catch {
+      frameResult["errors"] = [operationName: error.localizedDescription]
+    }
+    results.append(frameResult)
+  }
+
+  guard successCount > 0 else {
+    throw ValidationError("Every selected video frame failed \(operationName) analysis.")
+  }
+
+  return MediaAnalysisResult(
+    output: [
+      "input": input,
+      "durationSeconds": video.durationSeconds,
+      "frames": results,
+    ],
+    imageArtifact: nil
+  )
+}

--- a/Sources/seev/ShieldGemmaNSFWClassifier.swift
+++ b/Sources/seev/ShieldGemmaNSFWClassifier.swift
@@ -1,4 +1,7 @@
+import CoreGraphics
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
 
 enum NSFWClassifierError: LocalizedError {
   case modelNotInstalled(String)
@@ -22,7 +25,6 @@ enum NSFWClassifierError: LocalizedError {
 struct ShieldGemmaNSFWClassifier {
   static let defaultHost = "http://127.0.0.1:11434"
   static let model = "hf.co/infil00p/shieldgemma-2-4b-it-GGUF:Q4_K_M"
-  static let policyName = "nsfw"
 
   private static let prompt = """
     Review the image using only this policy:
@@ -89,6 +91,33 @@ struct ShieldGemmaNSFWClassifier {
       throw NSFWClassifierError.unknown("Could not read the image: \(error.localizedDescription)")
     }
 
+    return try await isNSFW(imageData: imageData)
+  }
+
+  func isNSFW(image: CGImage) async throws -> Bool {
+    let imageData = NSMutableData()
+    guard
+      let destination = CGImageDestinationCreateWithData(
+        imageData,
+        UTType.jpeg.identifier as CFString,
+        1,
+        nil
+      )
+    else {
+      throw NSFWClassifierError.unknown("Could not prepare the video frame for Ollama.")
+    }
+    CGImageDestinationAddImage(
+      destination,
+      image,
+      [kCGImageDestinationLossyCompressionQuality: 0.85] as CFDictionary
+    )
+    guard CGImageDestinationFinalize(destination) else {
+      throw NSFWClassifierError.unknown("Could not prepare the video frame for Ollama.")
+    }
+    return try await isNSFW(imageData: imageData as Data)
+  }
+
+  private func isNSFW(imageData: Data) async throws -> Bool {
     let payload = GenerateRequest(
       model: Self.model,
       prompt: Self.prompt,

--- a/Sources/seev/commands/all.swift
+++ b/Sources/seev/commands/all.swift
@@ -1,16 +1,14 @@
 import ArgumentParser
-import Foundation
-import Vision
 
-@available(macOS 12.0, *)
+@available(macOS 15.0, *)
 struct All: AsyncParsableCommand {
-  static var configuration: CommandConfiguration = CommandConfiguration(
-    abstract: "Performs all operations on an image and returns the results as JSON.",
+  static var configuration = CommandConfiguration(
+    abstract: "Performs all operations on an image or representative video frames.",
     discussion:
       "Successful operations are returned even when another operation fails. Failures are included in the errors object."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: MediaOptions
 
   @Option(
     name: [.customLong("ollama-host")],
@@ -19,233 +17,20 @@ struct All: AsyncParsableCommand {
   var ollamaHost = ShieldGemmaNSFWClassifier.defaultHost
 
   mutating func run() async throws {
-    try await runCombinedAnalysis(
+    var classifier: ShieldGemmaNSFWClassifier?
+    var nsfwSetupError: String?
+    do {
+      classifier = try ShieldGemmaNSFWClassifier(host: ollamaHost)
+    } catch {
+      nsfwSetupError = error.localizedDescription
+    }
+
+    try await runCombinedMediaAnalysis(
       input: args.input,
+      maxFrames: args.maxFrames,
       includeEmbeddings: true,
-      ollamaHost: ollamaHost
+      nsfwClassifier: classifier,
+      nsfwSetupError: nsfwSetupError
     )
   }
-}
-
-@available(macOS 12.0, *)
-func runCombinedAnalysis(
-  input: String,
-  includeEmbeddings: Bool,
-  ollamaHost: String?
-) async throws {
-  var result: [String: Any] = ["input": input]
-  var errors: [String: String] = [:]
-  var successCount = 0
-
-  func attempt<T>(_ name: String, _ operation: () throws -> T) -> T? {
-    do {
-      let value = try operation()
-      successCount += 1
-      return value
-    } catch {
-      errors[name] = error.localizedDescription
-      return nil
-    }
-  }
-
-  if let faces: [VNFaceObservation] = attempt(
-    "faces",
-    {
-      try performRequest(
-        request: VNDetectFaceRectanglesRequest(),
-        inputImagePath: input
-      )
-    })
-  {
-    var faceEmbeddingFailures = 0
-    result["faces"] = faces.map { face in
-      var faceResult: [String: Any] = [
-        "roll": face.roll ?? 0,
-        "yaw": face.yaw ?? 0,
-        "pitch": face.pitch ?? 0,
-        "boundingBox": [
-          "x": face.boundingBox.origin.x,
-          "y": face.boundingBox.origin.y,
-          "width": face.boundingBox.width,
-          "height": face.boundingBox.height,
-        ],
-        "confidence": face.confidence,
-      ]
-
-      guard includeEmbeddings else {
-        return faceResult
-      }
-
-      do {
-        let faceImage = try cropImage(
-          inputImagePath: input,
-          boundingBox: face.boundingBox
-        )
-        let featurePrint: [VNFeaturePrintObservation] = try performRequest(
-          request: VNGenerateImageFeaturePrintRequest(),
-          input: faceImage
-        )
-        guard let embedding = featurePrint.first else {
-          throw SeeVError.noFeaturePrintFound
-        }
-        faceResult["embedding"] = embedding.data.withUnsafeBytes {
-          Array($0.bindMemory(to: Float.self))
-        }
-      } catch {
-        faceEmbeddingFailures += 1
-      }
-      return faceResult
-    }
-    if faceEmbeddingFailures > 0 {
-      errors["faceEmbeddings"] =
-        "Failed to generate embeddings for \(faceEmbeddingFailures) of \(faces.count) faces."
-    }
-  }
-
-  if let humans: [VNHumanObservation] = attempt(
-    "humans",
-    {
-      try performRequest(
-        request: VNDetectHumanRectanglesRequest(),
-        inputImagePath: input
-      )
-    })
-  {
-    result["humans"] = humans.map { human in
-      [
-        "boundingBox": [
-          "x": human.boundingBox.origin.x,
-          "y": human.boundingBox.origin.y,
-          "width": human.boundingBox.width,
-          "height": human.boundingBox.height,
-        ],
-        "confidence": human.confidence,
-      ] as [String: Any]
-    }
-  }
-
-  let textRequest = VNRecognizeTextRequest()
-  textRequest.recognitionLevel = .accurate
-  textRequest.usesLanguageCorrection = true
-  if let text: [VNRecognizedTextObservation] = attempt(
-    "text",
-    {
-      try performRequest(request: textRequest, inputImagePath: input)
-    })
-  {
-    result["text"] = text.map { observation in
-      [
-        "boundingBox": [
-          "x": observation.boundingBox.origin.x,
-          "y": observation.boundingBox.origin.y,
-          "width": observation.boundingBox.width,
-          "height": observation.boundingBox.height,
-        ],
-        "text": observation.topCandidates(1).first?.string ?? "Failed to recognize text",
-        "confidence": observation.confidence,
-      ] as [String: Any]
-    }
-  }
-
-  if let poses: [VNHumanBodyPoseObservation] = attempt(
-    "poses",
-    {
-      try performRequest(
-        request: VNDetectHumanBodyPoseRequest(),
-        inputImagePath: input
-      )
-    })
-  {
-    result["poses"] = poses.map { pose in
-      [
-        "joints": pose.availableJointNames.compactMap { jointName -> [String: Any]? in
-          guard let point = try? pose.recognizedPoint(jointName) else {
-            return nil
-          }
-          return [
-            "name": jointName.rawValue,
-            "x": point.location.x,
-            "y": point.location.y,
-            "confidence": point.confidence,
-          ] as [String: Any]
-        }
-      ]
-    }
-  }
-
-  if let classifications: [VNClassificationObservation] = attempt(
-    "classifications",
-    {
-      try performRequest(
-        request: VNClassifyImageRequest(),
-        inputImagePath: input
-      )
-    })
-  {
-    result["classifications"] =
-      classifications
-      .filter { $0.confidence >= 0.4 }
-      .map { classification in
-        [
-          "identifier": classification.identifier,
-          "confidence": classification.confidence,
-        ] as [String: Any]
-      }
-  }
-
-  if includeEmbeddings {
-    if let embeddings: [VNFeaturePrintObservation] = attempt(
-      "embedding",
-      {
-        try performRequest(
-          request: VNGenerateImageFeaturePrintRequest(),
-          inputImagePath: input
-        )
-      })
-    {
-      if let embedding = embeddings.first {
-        result["embedding"] = embedding.data.withUnsafeBytes {
-          Array($0.bindMemory(to: Float.self))
-        }
-      } else {
-        errors["embedding"] = String(describing: SeeVError.noFeaturePrintFound)
-      }
-    }
-  }
-
-  if let sha1 = attempt(
-    "sha1",
-    {
-      try hashFile(inputImagePath: input)
-    })
-  {
-    result["sha1"] = sha1
-  }
-
-  if let ollamaHost {
-    do {
-      let classifier = try ShieldGemmaNSFWClassifier(host: ollamaHost)
-      let violation = try await classifier.isNSFW(imageAt: inputImagePathToURL(input))
-      result["nsfw"] = [
-        "model": ShieldGemmaNSFWClassifier.model,
-        "policy": ShieldGemmaNSFWClassifier.policyName,
-        "violation": violation,
-      ]
-      successCount += 1
-    } catch {
-      errors["nsfw"] = error.localizedDescription
-    }
-  }
-
-  guard successCount > 0 else {
-    let summary = errors.sorted { $0.key < $1.key }
-      .map { "\($0.key): \($0.value)" }
-      .joined(separator: "; ")
-    throw ValidationError("All operations failed. \(summary)")
-  }
-
-  if !errors.isEmpty {
-    result["errors"] = errors
-  }
-  printDict(result)
 }

--- a/Sources/seev/commands/classify.swift
+++ b/Sources/seev/commands/classify.swift
@@ -1,55 +1,36 @@
 import ArgumentParser
-import Foundation
-import Vision
 
-@available(macOS 10.15, *)
-struct Classify: ParsableCommand {
-  static var configuration: CommandConfiguration = CommandConfiguration(
-    abstract: "Classify an image using a Core ML model.",
+@available(macOS 15.0, *)
+struct Classify: AsyncParsableCommand {
+  static var configuration = CommandConfiguration(
+    abstract: "Classifies an image or representative video frames using Vision.",
     discussion: "A list of classifications and their confidence levels."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: MediaOptions
+
   @Option(name: .shortAndLong, help: "Minimum confidence for predictions.")
   var minimumConfidence: Float = 0.4
+
   @Option(
     name: .shortAndLong,
     parsing: .upToNextOption,
-    help: "Identifiers to include even if they don't meet the minimum confidence.")
+    help: "Identifiers to include even if they don't meet the minimum confidence."
+  )
   var includeIdentifiers: [String] = []
 
-  mutating func run() {
-    do {
-      let classifications: [VNClassificationObservation] = try performRequest(
-        request: VNClassifyImageRequest(),
-        inputImagePath: args.input
+  mutating func run() async throws {
+    let result = try await analyzeMedia(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      operationName: "classifications"
+    ) { input in
+      try classificationAnalysis(
+        input: input,
+        minimumConfidence: minimumConfidence,
+        includeIdentifiers: includeIdentifiers
       )
-      let filteredClassifications = classifications.filter { $0.confidence >= minimumConfidence }
-      var classificiationsDict: [String: Any] = [
-        "input": args.input,
-        "classifications": filteredClassifications.map { classification in
-          [
-            "identifier": classification.identifier,
-            "confidence": classification.confidence,
-          ]
-        },
-      ]
-      for identifier in includeIdentifiers {
-        if !filteredClassifications.contains(where: { $0.identifier == identifier }) {
-          var mutableClassifications = classificiationsDict["classifications"] as! [[String: Any]]
-          mutableClassifications.append([
-            "identifier": identifier,
-            "confidence": classifications.first(where: { $0.identifier == identifier })?.confidence
-              ?? 0,
-          ])
-          classificiationsDict["classifications"] = mutableClassifications
-        }
-      }
-      printDict(classificiationsDict)
-
-    } catch {
-      print("Error: \(error)")
     }
+    printDict(result.output)
   }
-
 }

--- a/Sources/seev/commands/distance.swift
+++ b/Sources/seev/commands/distance.swift
@@ -17,9 +17,13 @@ struct Distance: ParsableCommand {
   var secondImage: String
 
   mutating func run() throws {
-    let req1 = VNGenerateImageFeaturePrintRequest()
-    let embeddings1: [VNFeaturePrintObservation] = try performRequest(
-      request: req1, inputImagePath: firstImage
+    guard !isVideoInput(firstImage), !isVideoInput(secondImage) else {
+      throw ValidationError("Distance supports images only.")
+    }
+
+    let firstInput = AnalysisInput.url(inputImagePathToURL(firstImage))
+    let embeddings1: [VNFeaturePrintObservation] = try firstInput.perform(
+      VNGenerateImageFeaturePrintRequest()
     )
     guard let embedding1 = embeddings1.first else {
       throw SeeVError.noFeaturePrintFound
@@ -28,9 +32,9 @@ struct Distance: ParsableCommand {
       Array($0.bindMemory(to: Float.self))
     }
 
-    let req2 = VNGenerateImageFeaturePrintRequest()
-    let embeddings2: [VNFeaturePrintObservation] = try performRequest(
-      request: req2, inputImagePath: secondImage
+    let secondInput = AnalysisInput.url(inputImagePathToURL(secondImage))
+    let embeddings2: [VNFeaturePrintObservation] = try secondInput.perform(
+      VNGenerateImageFeaturePrintRequest()
     )
     guard let embedding2 = embeddings2.first else {
       throw SeeVError.noFeaturePrintFound

--- a/Sources/seev/commands/embeddings.swift
+++ b/Sources/seev/commands/embeddings.swift
@@ -1,30 +1,21 @@
 import ArgumentParser
-import Foundation
-import Vision
 
-@available(macOS 12.0, *)
-struct Embeddings: ParsableCommand {
-
+@available(macOS 15.0, *)
+struct Embeddings: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
-    abstract: "Extracts embeddings from an image and returns the results as JSON.",
-    discussion: "The JSON output includes the embeddings of the input image."
+    abstract: "Extracts embeddings from an image or representative video frames.",
+    discussion: "The JSON output includes the embeddings of the analyzed input."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: MediaOptions
 
-  mutating func run() throws {
-    let embeddings: [VNFeaturePrintObservation] = try performRequest(
-      request: VNGenerateImageFeaturePrintRequest(),
-      inputImagePath: args.input
+  mutating func run() async throws {
+    let result = try await analyzeMedia(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      operationName: "embedding",
+      analysis: embeddingAnalysis
     )
-    guard let embedding = embeddings.first else {
-      throw SeeVError.noFeaturePrintFound
-    }
-    printDict([
-      "input": args.input,
-      "embedding": embedding.data.withUnsafeBytes {
-        Array($0.bindMemory(to: Float.self))
-      },
-    ])
+    printDict(result.output)
   }
 }

--- a/Sources/seev/commands/faces.swift
+++ b/Sources/seev/commands/faces.swift
@@ -1,92 +1,67 @@
 import ArgumentParser
-import Foundation
 import Vision
 
-@available(macOS 14.0, *)
-struct Faces: ParsableCommand {
+@available(macOS 15.0, *)
+struct Faces: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
-    abstract: "Detects faces in an image and returns the results as JSON.",
+    abstract: "Detects faces in an image or representative video frames.",
     discussion:
       "The JSON output includes the roll, yaw, pitch, bounding box, and confidence of each face. If an output path is provided, a PNG image with the bounding boxes drawn will be saved."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: MediaOutputOptions
+
   @Flag(
     name: [.customShort("c"), .long],
-    help: "Crop the output to the largest face bounding box found")
-  var cropped: Bool = false
+    help: "Crop the output to the largest face bounding box found"
+  )
+  var cropped = false
 
   @Flag(
     name: [.customShort("e"), .long],
     help: "Generate embeddings for each cropped face"
   )
-  var embeddings: Bool = false
+  var embeddings = false
 
-  mutating func run() {
-    do {
-      let faces: [VNFaceObservation] = try performRequest(
-        request: VNDetectFaceRectanglesRequest(),
-        inputImagePath: args.input
-      )
-      printDict([
-        "input": args.input,
-        "faces": faces.map { face in
-          var result =
-            [
-              "roll": face.roll ?? 0,
-              "yaw": face.yaw ?? 0,
-              "pitch": face.pitch ?? 0,
-              "boundingBox": [
-                "x": face.boundingBox.origin.x,
-                "y": face.boundingBox.origin.y,
-                "width": face.boundingBox.width,
-                "height": face.boundingBox.height,
-              ],
-              "confidence": face.confidence,
-            ] as [String: Any]
-          if embeddings {
-            let faceImage = try? cropImage(
-              inputImagePath: args.input,
-              boundingBox: face.boundingBox
-            )
-            if faceImage == nil { return result }
-            let request = VNGenerateImageFeaturePrintRequest()
-            let featurePrint: [VNFeaturePrintObservation]? = try? performRequest(
-              request: request,
-              input: faceImage!
-            )
-            if featurePrint == nil { return result }
-            result["embedding"] = featurePrint!.first!.data.withUnsafeBytes {
-              Array($0.bindMemory(to: Float.self))
-            }
-          }
-          return result
-        },
-      ])
-      if cropped {
-        let largestFace = faces.max {
-          $0.boundingBox.width * $0.boundingBox.height < $1.boundingBox.width
-            * $1.boundingBox.height
-        }
-        if largestFace != nil {
-          let output = try cropImage(
-            inputImagePath: args.input, boundingBox: largestFace!.boundingBox)
-          saveOutput(output: output, outputImagePath: args.output!)
-          print("Saved cropped image to \(args.output!)")
-        } else {
-          throw SeeVError.noSubjectFound
-        }
-      } else if args.output != nil {
-        draw(
-          inputImagePath: args.input,
-          outputImagePath: args.output!,
-          points: [],
-          boxes: faces.map(\.boundingBox),
-          lines: [])
-        print("Saved bounding boxes to \(args.output!)")
+  mutating func run() async throws {
+    try args.validateImageOutput(cropped: cropped)
+
+    let result = try await analyzeMedia(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      operationName: "faces"
+    ) { input in
+      try faceAnalysis(input: input, includeEmbeddings: embeddings)
+    }
+    printDict(result.output)
+
+    guard let artifact = result.imageArtifact else {
+      return
+    }
+    if cropped {
+      guard
+        let largestFace = artifact.observations.max(by: {
+          $0.boundingBox.width * $0.boundingBox.height
+            < $1.boundingBox.width * $1.boundingBox.height
+        })
+      else {
+        throw SeeVError.noSubjectFound
       }
-    } catch {
-      print("Error: \(error)")
+      let output = try cropImage(
+        inputImagePath: args.input,
+        boundingBox: largestFace.boundingBox
+      )
+      saveOutput(output: output, outputImagePath: args.output!)
+      printStatus("Saved cropped image to \(args.output!)")
+    } else if let output = args.output {
+      draw(
+        inputImagePath: args.input,
+        outputImagePath: output,
+        points: [],
+        boxes: artifact.observations.map(\.boundingBox),
+        lines: []
+      )
+      printStatus("Saved bounding boxes to \(output)")
     }
   }
 }

--- a/Sources/seev/commands/humans.swift
+++ b/Sources/seev/commands/humans.swift
@@ -1,50 +1,35 @@
 import ArgumentParser
-import Foundation
-import Vision
 
-@available(macOS 12.0, *)
-struct Humans: ParsableCommand {
-
+@available(macOS 15.0, *)
+struct Humans: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
-    abstract: "Detects humans in an image and returns the results as JSON.",
+    abstract: "Detects humans in an image or representative video frames.",
     discussion:
       "The JSON output includes the bounding box and confidence of each human. If an output path is provided, a PNG image with the bounding boxes drawn will be saved."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: MediaOutputOptions
 
-  mutating func run() {
-    do {
-      let humans: [VNHumanObservation] = try performRequest(
-        request: VNDetectHumanRectanglesRequest(),
-        inputImagePath: args.input
+  mutating func run() async throws {
+    try args.validateImageOutput()
+
+    let result = try await analyzeMedia(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      operationName: "humans",
+      analysis: humanAnalysis
+    )
+    printDict(result.output)
+
+    if let humans = result.imageArtifact, let output = args.output {
+      draw(
+        inputImagePath: args.input,
+        outputImagePath: output,
+        points: [],
+        boxes: humans.map(\.boundingBox),
+        lines: []
       )
-      printDict([
-        "input": args.input,
-        "humans": humans.map { human in
-          return [
-            "boundingBox": [
-              "x": human.boundingBox.origin.x,
-              "y": human.boundingBox.origin.y,
-              "width": human.boundingBox.width,
-              "height": human.boundingBox.height,
-            ],
-            "confidence": human.confidence,
-          ] as [String: Any]
-        },
-      ])
-      if args.output != nil {
-        draw(
-          inputImagePath: args.input,
-          outputImagePath: args.output!,
-          points: [],
-          boxes: humans.map(\.boundingBox),
-          lines: []
-        )
-        print("Saved bounding boxes to \(args.output!)")
-      }
-    } catch {
-      print("Error: \(error)")
+      printStatus("Saved bounding boxes to \(output)")
     }
   }
 }

--- a/Sources/seev/commands/most.swift
+++ b/Sources/seev/commands/most.swift
@@ -1,17 +1,21 @@
 import ArgumentParser
 
-@available(macOS 12.0, *)
+@available(macOS 15.0, *)
 struct Most: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
-    abstract: "Performs combined image analysis without embeddings or NSFW classification.",
+    abstract:
+      "Performs combined analysis on an image or representative video frames without embeddings or NSFW classification.",
     discussion:
-      "Runs faces, humans, text, poses, classification, and SHA-1 without requiring Ollama."
+      "Runs faces, humans, text, poses, classification, quality, and SHA-1 without requiring Ollama."
   )
 
-  @Argument(help: "The filepath of the input image")
-  var input: String
+  @OptionGroup var args: MediaOptions
 
   mutating func run() async throws {
-    try await runCombinedAnalysis(input: input, includeEmbeddings: false, ollamaHost: nil)
+    try await runCombinedMediaAnalysis(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      includeEmbeddings: false
+    )
   }
 }

--- a/Sources/seev/commands/nsfw.swift
+++ b/Sources/seev/commands/nsfw.swift
@@ -1,14 +1,13 @@
 import ArgumentParser
-import Foundation
 
-@available(macOS 12.0, *)
+@available(macOS 15.0, *)
 struct NSFW: AsyncParsableCommand {
-  static var configuration: CommandConfiguration = CommandConfiguration(
-    abstract: "Checks whether an image is NSFW using ShieldGemma through Ollama."
+  static var configuration = CommandConfiguration(
+    abstract:
+      "Checks whether an image or representative video frames are NSFW using ShieldGemma through Ollama."
   )
 
-  @Argument(help: "The filepath of the input image")
-  var input: String
+  @OptionGroup var args: MediaOptions
 
   @Option(
     name: [.customLong("ollama-host")],
@@ -18,13 +17,19 @@ struct NSFW: AsyncParsableCommand {
 
   mutating func run() async throws {
     let classifier = try ShieldGemmaNSFWClassifier(host: ollamaHost)
-    let violation = try await classifier.isNSFW(imageAt: inputImagePathToURL(input))
-
-    printDict([
-      "input": input,
-      "model": ShieldGemmaNSFWClassifier.model,
-      "policy": ShieldGemmaNSFWClassifier.policyName,
-      "violation": violation,
-    ])
+    let result = try await analyzeMedia(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      operationName: "nsfw"
+    ) { input in
+      FrameAnalysisResult(output: [
+        "nsfw": try await input.isNSFW(using: classifier)
+      ])
+    }
+    if let nsfw = result.output["nsfw"] {
+      printJSON(nsfw)
+    } else {
+      printDict(result.output)
+    }
   }
 }

--- a/Sources/seev/commands/poses.swift
+++ b/Sources/seev/commands/poses.swift
@@ -1,80 +1,68 @@
 import ArgumentParser
-import Foundation
+import CoreGraphics
 import Vision
 
-@available(macOS 11.0, *)
-struct Poses: ParsableCommand {
-  static var configuration: CommandConfiguration = CommandConfiguration(
-    abstract: "Detects the poses of humans in an image.",
+@available(macOS 15.0, *)
+struct Poses: AsyncParsableCommand {
+  static var configuration = CommandConfiguration(
+    abstract: "Detects human poses in an image or representative video frames.",
     discussion: "The JSON output."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: MediaOutputOptions
 
-  mutating func run() {
-    do {
-      let request = VNDetectHumanBodyPoseRequest()
-      let poses: [VNHumanBodyPoseObservation] =
-        try performRequest(
-          request: request, inputImagePath: args.input)
-      let posesDict: [String: Any] = [
-        "input": args.input,
-        "poses": poses.map { pose in
-          [
-            "joints": pose.availableJointNames.map {
-              [
-                "name": $0.rawValue,
-                "x": try! pose.recognizedPoint($0).location.x,
-                "y": try! pose.recognizedPoint($0).location.y,
-                "confidence": try! pose.recognizedPoint($0).confidence,
-              ]
-            }
-          ]
-        },
-      ]
-      printDict(posesDict)
-      let points: [CGPoint] = poses.flatMap { pose in
-        pose.availableJointNames.map {
-          try! pose.recognizedPoint($0).location
-        }
-      }
-      var lines: [(CGPoint, CGPoint)] = []
-      for pose in poses {
-        func addPair(
-          _ A: VNHumanBodyPoseObservation.JointName, _ B: VNHumanBodyPoseObservation.JointName
-        ) {
-          if pose.availableJointNames.contains(A) && pose.availableJointNames.contains(B) {
-            let pointA = try! pose.recognizedPoint(A)
-            let pointB = try! pose.recognizedPoint(B)
-            if pointA.confidence < 0.5 || pointB.confidence < 0.5 {
-              return
-            }
-            lines.append(
-              (
-                pointA.location,
-                pointB.location
-              ))
-          }
-        }
-        addPair(.neck, .root)
-        addPair(.leftShoulder, .rightShoulder)
-        addPair(.leftShoulder, .leftElbow)
-        addPair(.rightShoulder, .rightElbow)
-        addPair(.leftElbow, .leftWrist)
-        addPair(.rightElbow, .rightWrist)
-        addPair(.leftHip, .rightHip)
-        addPair(.leftHip, .leftKnee)
-        addPair(.rightHip, .rightKnee)
-        addPair(.leftKnee, .leftAnkle)
-        addPair(.rightKnee, .rightAnkle)
-      }
-      if args.output != nil {
-        draw(
-          inputImagePath: args.input, outputImagePath: args.output!, points: points,
-          boxes: [], lines: lines)
-      }
-    } catch {
-      print("Error: \(error)")
+  mutating func run() async throws {
+    try args.validateImageOutput()
+
+    let result = try await analyzeMedia(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      operationName: "poses",
+      analysis: poseAnalysis
+    )
+    printDict(result.output)
+
+    if let poses = result.imageArtifact, let output = args.output {
+      draw(
+        inputImagePath: args.input,
+        outputImagePath: output,
+        points: poses.flatMap(posePoints),
+        boxes: [],
+        lines: poses.flatMap(poseLines)
+      )
     }
+  }
+}
+
+private func posePoints(_ pose: VNHumanBodyPoseObservation) -> [CGPoint] {
+  pose.availableJointNames.compactMap { jointName in
+    try? pose.recognizedPoint(jointName).location
+  }
+}
+
+private func poseLines(_ pose: VNHumanBodyPoseObservation) -> [(CGPoint, CGPoint)] {
+  let pairs: [(VNHumanBodyPoseObservation.JointName, VNHumanBodyPoseObservation.JointName)] = [
+    (.neck, .root),
+    (.leftShoulder, .rightShoulder),
+    (.leftShoulder, .leftElbow),
+    (.rightShoulder, .rightElbow),
+    (.leftElbow, .leftWrist),
+    (.rightElbow, .rightWrist),
+    (.leftHip, .rightHip),
+    (.leftHip, .leftKnee),
+    (.rightHip, .rightKnee),
+    (.leftKnee, .leftAnkle),
+    (.rightKnee, .rightAnkle),
+  ]
+  return pairs.compactMap { firstJoint, secondJoint in
+    guard
+      let pointA = try? pose.recognizedPoint(firstJoint),
+      let pointB = try? pose.recognizedPoint(secondJoint),
+      pointA.confidence >= 0.5,
+      pointB.confidence >= 0.5
+    else {
+      return nil
+    }
+    return (pointA.location, pointB.location)
   }
 }

--- a/Sources/seev/commands/quality.swift
+++ b/Sources/seev/commands/quality.swift
@@ -1,28 +1,20 @@
 import ArgumentParser
-import Vision
 
 @available(macOS 15.0, *)
-struct Quality: ParsableCommand {
+struct Quality: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
-    abstract: "Scores the aesthetic quality of an image."
+    abstract: "Scores the aesthetic quality of an image or representative video frames."
   )
 
-  @Argument(help: "The filepath of the input image")
-  var input: String
+  @OptionGroup var args: MediaOptions
 
-  mutating func run() throws {
-    let observations: [VNImageAestheticsScoresObservation] = try performRequest(
-      request: VNCalculateImageAestheticsScoresRequest(),
-      inputImagePath: input
+  mutating func run() async throws {
+    let result = try await analyzeMedia(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      operationName: "quality",
+      analysis: qualityAnalysis
     )
-    guard let quality = observations.first else {
-      throw ValidationError("Vision did not return an image quality score.")
-    }
-
-    printDict([
-      "input": input,
-      "overallScore": quality.overallScore,
-      "isUtility": quality.isUtility,
-    ])
+    printDict(result.output)
   }
 }

--- a/Sources/seev/commands/sha1.swift
+++ b/Sources/seev/commands/sha1.swift
@@ -8,7 +8,7 @@ struct SHA1: ParsableCommand {
     abstract: "Hashes the image using the SHA-1 algorithm."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: InputOptions
 
   mutating func run() {
     do {

--- a/Sources/seev/commands/subject.swift
+++ b/Sources/seev/commands/subject.swift
@@ -12,28 +12,25 @@ struct Subject: ParsableCommand {
   static var configuration = CommandConfiguration(
     abstract: "Removes the background from an image.",
     discussion:
-      "The output image will have the background removed. If the --cropped flag is provided, the output will be cropped to the subject's bounding box. If the --stdout flag is provided, the output will be written to stdout."
+      "The output image will have the background removed. If the --cropped flag is provided, the output will be cropped to the subject's bounding box. Without --output, the PNG is written to stdout."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: ImageOutputOptions
   @Flag(name: [.customShort("c"), .long], help: "Crop the output to the subject's bounding box")
   var cropped: Bool = false
 
-  @Flag(name: [.long], help: "Write output to stdout")
-  var stdout: Bool = false
+  mutating func run() throws {
+    guard !isVideoInput(args.input) else {
+      throw ValidationError("Subject extraction supports images only.")
+    }
 
-  mutating func run() {
-    do {
-      print("Removing background from \(args.input)...")
-      let output = try extractSubject(inputImagePath: args.input, cropped: cropped)
-      if args.output == nil {
-        try writeOutput(output: output)
-      } else {
-        saveOutput(output: output, outputImagePath: args.output!)
-        print("Saved to \(args.output!)")
-      }
-    } catch {
-      print("Error: \(error)")
+    printStatus("Removing background from \(args.input)...")
+    let output = try extractSubject(inputImagePath: args.input, cropped: cropped)
+    if let outputPath = args.output {
+      saveOutput(output: output, outputImagePath: outputPath)
+      printStatus("Saved to \(outputPath)")
+    } else {
+      try writeOutput(output: output)
     }
   }
 }

--- a/Sources/seev/commands/text.swift
+++ b/Sources/seev/commands/text.swift
@@ -1,60 +1,44 @@
 import ArgumentParser
-import Foundation
-import Vision
 
 @available(macOS 15.0, *)
-struct Text: ParsableCommand {
+struct Text: AsyncParsableCommand {
   static var configuration = CommandConfiguration(
-    abstract: "Detects text in an image and returns the results as JSON.",
+    abstract: "Detects text in an image or representative video frames.",
     discussion:
       "The JSON output includes the bounding box, text, and confidence of each detected text. If an output path is provided, a PNG image with the bounding boxes drawn will be saved."
   )
 
-  @OptionGroup() var args: Options
+  @OptionGroup var args: MediaOutputOptions
+
   @Option(
     name: [.customLong("custom-words")],
     parsing: .upToNextOption,
-    help: "Custom words to use for text recognition")
+    help: "Custom words to use for text recognition"
+  )
   var customWords: [String] = []
 
-  mutating func run() {
-    do {
-      let request = VNRecognizeTextRequest()
-      request.recognitionLevel = .accurate
-      request.usesLanguageCorrection = true
-      request.customWords = customWords
-      let text: [VNRecognizedTextObservation] = try performRequest(
-        request: request,
-        inputImagePath: args.input
+  mutating func run() async throws {
+    try args.validateImageOutput()
+
+    var result = try await analyzeMedia(
+      input: args.input,
+      maxFrames: args.maxFrames,
+      operationName: "text"
+    ) { input in
+      try textAnalysis(input: input, customWords: customWords)
+    }
+    result.output["customWords"] = customWords
+    printDict(result.output)
+
+    if let text = result.imageArtifact, let output = args.output {
+      draw(
+        inputImagePath: args.input,
+        outputImagePath: output,
+        points: [],
+        boxes: text.map(\.boundingBox),
+        lines: []
       )
-      printDict([
-        "input": args.input,
-        "customWords": customWords,
-        "text": text.map { text in
-          return [
-            "boundingBox": [
-              "x": text.boundingBox.origin.x,
-              "y": text.boundingBox.origin.y,
-              "width": text.boundingBox.width,
-              "height": text.boundingBox.height,
-            ],
-            "text": text.topCandidates(1).first?.string ?? "Failed to recognize text",
-            "confidence": text.confidence,
-          ] as [String: Any]
-        },
-      ])
-      if args.output != nil {
-        draw(
-          inputImagePath: args.input,
-          outputImagePath: args.output!,
-          points: [],
-          boxes: text.map(\.boundingBox),
-          lines: []
-        )
-        print("Saved bounding boxes to \(args.output!)")
-      }
-    } catch {
-      print("Error: \(error)")
+      printStatus("Saved bounding boxes to \(output)")
     }
   }
 }

--- a/Sources/seev/helpers.swift
+++ b/Sources/seev/helpers.swift
@@ -22,28 +22,6 @@ func inputImagePathToURL(_ inputImagePath: String) -> URL {
   }
 }
 
-/// Perform a Vision request on the input image and return the results as an array of the specified type
-func performRequest<T: VNObservation>(request: VNRequest, inputImagePath: String) throws -> [T] {
-  let inputURL = inputImagePathToURL(inputImagePath)
-  let handler = VNImageRequestHandler(url: inputURL)
-  // Get the type of what the request results are
-  try handler.perform([request])
-  guard let results = request.results else {
-    return []
-  }
-  return results as! [T]
-}
-
-// performRequest with a CGImage input
-func performRequest<T: VNObservation>(request: VNRequest, input: CGImage) throws -> [T] {
-  let handler = VNImageRequestHandler(cgImage: input)
-  try handler.perform([request])
-  guard let results = request.results else {
-    return []
-  }
-  return results as! [T]
-}
-
 func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
   let dotProduct = zip(a, b).map(*).reduce(0, +)
   let magnitudeA = sqrt(a.map { $0 * $0 }.reduce(0, +))
@@ -54,7 +32,13 @@ func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
 /// Crop the input image using the specified bounding box and return the result as a CGImage
 func cropImage(inputImagePath: String, boundingBox: CGRect) throws -> CGImage {
   let inputURL = inputImagePathToURL(inputImagePath)
-  let inputImage = CIImage(contentsOf: inputURL)!
+  return try cropImage(inputURL: inputURL, boundingBox: boundingBox)
+}
+
+func cropImage(inputURL: URL, boundingBox: CGRect) throws -> CGImage {
+  guard let inputImage = CIImage(contentsOf: inputURL) else {
+    throw SeeVError.outputError
+  }
   let adjustedBoundingBox = CGRect(
     x: boundingBox.origin.x * inputImage.extent.width,
     y: boundingBox.origin.y * inputImage.extent.height,
@@ -63,8 +47,27 @@ func cropImage(inputImagePath: String, boundingBox: CGRect) throws -> CGImage {
   )
   let croppedImage = inputImage.cropped(to: adjustedBoundingBox)
   let context = CIContext(options: nil)
-  let cgImage = context.createCGImage(croppedImage, from: croppedImage.extent)!
-  return cgImage
+  guard let image = context.createCGImage(croppedImage, from: croppedImage.extent) else {
+    throw SeeVError.outputError
+  }
+  return image
+}
+
+/// Crop a CGImage using a normalized Vision bounding box.
+func cropImage(input: CGImage, boundingBox: CGRect) throws -> CGImage {
+  let inputImage = CIImage(cgImage: input)
+  let adjustedBoundingBox = CGRect(
+    x: boundingBox.origin.x * inputImage.extent.width,
+    y: boundingBox.origin.y * inputImage.extent.height,
+    width: boundingBox.width * inputImage.extent.width,
+    height: boundingBox.height * inputImage.extent.height
+  )
+  let croppedImage = inputImage.cropped(to: adjustedBoundingBox)
+  let context = CIContext(options: nil)
+  guard let image = context.createCGImage(croppedImage, from: croppedImage.extent) else {
+    throw SeeVError.outputError
+  }
+  return image
 }
 
 @available(macOS 11.0, *)
@@ -140,8 +143,21 @@ func writeOutput(output: CGImage) throws {
   stdout.write(png)
 }
 
+/// Print a human-readable status message to stderr.
+func printStatus(_ message: String) {
+  FileHandle.standardError.write(Data("\(message)\n".utf8))
+}
+
 /// Print a JSON dictionary to stdout
 func printDict(_ dict: [String: Any]) {
-  let jsonData = try! JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+  printJSON(dict)
+}
+
+/// Print any JSON value to stdout
+func printJSON(_ value: Any) {
+  let jsonData = try! JSONSerialization.data(
+    withJSONObject: value,
+    options: [.prettyPrinted, .fragmentsAllowed]
+  )
   print(String(data: jsonData, encoding: .utf8)!)
 }

--- a/Sources/seev/seev.swift
+++ b/Sources/seev/seev.swift
@@ -1,14 +1,57 @@
 import ArgumentParser
 import Foundation
 
-let VERSION = "2.3.0"
+let VERSION = "2.4.0"
 
-struct Options: ParsableArguments {
+private func positiveInteger(_ argument: String) throws -> Int {
+  guard let value = Int(argument), value > 0 else {
+    throw ValidationError("must be a positive integer")
+  }
+  return value
+}
+
+struct InputOptions: ParsableArguments {
+  @Argument(help: "The filepath of the input file")
+  var input: String
+}
+
+struct ImageOutputOptions: ParsableArguments {
   @Argument(help: "The filepath of the input image")
   var input: String
 
   @Option(name: [.customShort("o"), .long], help: "The filepath of the output image")
   var output: String?
+}
+
+struct MediaOptions: ParsableArguments {
+  @Argument(help: "The filepath of the input image or video")
+  var input: String
+
+  @Option(
+    name: [.customLong("max-frames")],
+    help: "Maximum representative frames to analyze for video input.",
+    transform: positiveInteger
+  )
+  var maxFrames = defaultMaxFrames
+}
+
+struct MediaOutputOptions: ParsableArguments {
+  @OptionGroup var media: MediaOptions
+
+  @Option(name: [.customShort("o"), .long], help: "The filepath of the output image")
+  var output: String?
+
+  var input: String { media.input }
+  var maxFrames: Int { media.maxFrames }
+
+  func validateImageOutput(cropped: Bool = false) throws {
+    if isVideoInput(input), output != nil || cropped {
+      throw VideoInputError.imageOutputUnsupported
+    }
+    if cropped, output == nil {
+      throw ValidationError("--cropped requires --output.")
+    }
+  }
 }
 
 @available(macOS 15.0, *)


### PR DESCRIPTION
## Summary
- accept video input in faces, humans, text, embeddings, classify, poses, quality, nsfw, all, and most
- add --max-frames with a default of 10 and return durationSeconds plus per-frame timestampSeconds
- batch-decode representative frames with AVFoundation, approximate keyframe seeking, bounded resolution, and one fallback pass for decode failures
- preserve repeated detections in every frame where they occur
- return NSFW as a boolean in combined results while keeping model and policy once at the top level for standalone nsfw video output
- keep SHA-1 file-based and explicitly reject video input for distance, subject extraction, and rendered image output modes
- document the video schema, sampling behavior, performance tradeoffs, and moderation limitations
- bump seeV to 2.4.0 and declare its existing macOS 15 package requirement

## Verification
- swift build --configuration release
- format lint and git diff checks
- image regression checks for faces, humans, text, embeddings, classify, poses, quality, and most
- video checks for every supported command using a temporary 6.5-second MP4 made from repository demos with black bookends and repeated face/text frames
- verified default and explicit frame limits, ordered actual timestamps, valid JSON, and repeated detections
- verified invalid frame limits and unsupported video output modes return nonzero statuses
- live Ollama checks for nsfw and all on both image and video inputs
- verified all preserves Vision results and reports errors.nsfw when Ollama configuration fails

The temporary test MP4 was not committed, and ffmpeg is not a runtime dependency.