### PR TITLE
Add ffmpeg fallback for unsupported videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 seeV is a macOS command line wrapper around the [Apple Vision framework](https://developer.apple.com/documentation/vision). Its goal is to unlock the functionality of the framework for images and videos in shell scripts and other command line tools. seeV is written in Swift and requires macOS 15 or later.
 
-Most seeV operations have no runtime dependencies or network requirements because Vision.framework ships with macOS. The `nsfw` command and the NSFW phase of `all` additionally require [Ollama](https://ollama.com/) and an installed image-capable [ShieldGemma 2](https://huggingface.co/google/shieldgemma-2-4b-it) model. The `most` command never uses Ollama.
+Most seeV operations have no runtime dependencies or network requirements because Vision.framework ships with macOS. Video formats that AVFoundation cannot decode, including WebM on macOS, require [ffmpeg](https://ffmpeg.org/). The `nsfw` command and the NSFW phase of `all` additionally require [Ollama](https://ollama.com/) and an installed image-capable [ShieldGemma 2](https://huggingface.co/google/shieldgemma-2-4b-it) model. The `most` command never uses Ollama.
 
 ## Supported Operations
 
@@ -202,7 +202,7 @@ seev most input.mp4
 
 `faces`, `humans`, `text`, `embeddings`, `classify`, `poses`, `quality`, `nsfw`, `all`, and `most` accept video input. The only video-specific option is `--max-frames`, which defaults to `10` and sets an upper bound on the number of representative frames analyzed.
 
-Video results contain the duration and the actual timestamp of each decoded frame:
+Video results contain the duration and timestamp associated with each decoded frame:
 
 ```json
 {
@@ -218,7 +218,15 @@ Video results contain the duration and the actual timestamp of each decoded fram
 }
 ```
 
-Frames are sampled from the center of evenly spaced time ranges for broad temporal coverage, avoiding the exact beginning and end of the video. seeV asks AVFoundation for nearby keyframes and scales them to a maximum dimension of 1280 pixels for faster analysis. If a frame cannot be decoded, seeV makes one nearby fallback attempt. The same face, text, or other result remains present in every sampled frame where it is detected; results are not deduplicated across frames.
+Frames are sampled from the center of evenly spaced time ranges for broad temporal coverage, avoiding the exact beginning and end of the video. seeV first uses AVFoundation to decode nearby keyframes and scales them to a maximum dimension of 1280 pixels for faster analysis. If an AVFoundation frame cannot be decoded, seeV makes one nearby fallback attempt.
+
+When AVFoundation cannot open a video format, seeV falls back to `ffprobe` for duration and `ffmpeg` for representative-frame extraction. The fallback writes at most `--max-frames` temporary JPEGs, loads them into memory, and removes the temporary directory before returning the frames for analysis. Install both tools with:
+
+```sh
+brew install ffmpeg
+```
+
+The same face, text, or other result remains present in every sampled frame where it is detected; results are not deduplicated across frames.
 
 For images, standalone `nsfw` returns a JSON boolean. For videos, each frame contains an `nsfw` boolean alongside its timestamp. Per-operation failures remain under the frame's `errors` object.
 

--- a/Sources/seev/FFmpegFrameExtractor.swift
+++ b/Sources/seev/FFmpegFrameExtractor.swift
@@ -1,0 +1,189 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+enum FFmpegFrameExtractionError: LocalizedError {
+  case unavailable
+  case failed(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .unavailable:
+      return
+        "ffmpeg and ffprobe must be installed and available on PATH. Install them with 'brew install ffmpeg'."
+    case .failed(let reason):
+      return reason
+    }
+  }
+}
+
+struct FFmpegFrameExtractor {
+  private let ffmpeg: URL
+  private let ffprobe: URL
+
+  init() throws {
+    guard
+      let ffmpeg = Self.executable(named: "ffmpeg"),
+      let ffprobe = Self.executable(named: "ffprobe")
+    else {
+      throw FFmpegFrameExtractionError.unavailable
+    }
+    self.ffmpeg = ffmpeg
+    self.ffprobe = ffprobe
+  }
+
+  func extract(input: String, maxFrames: Int) throws -> VideoFrames {
+    let sourceURL = inputImagePathToURL(input)
+    let source = sourceURL.isFileURL ? sourceURL.path : sourceURL.absoluteString
+    let durationSeconds = try duration(of: source)
+    let temporaryDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("seev-frames-\(UUID().uuidString)", isDirectory: true)
+    do {
+      try FileManager.default.createDirectory(
+        at: temporaryDirectory,
+        withIntermediateDirectories: false
+      )
+    } catch {
+      throw FFmpegFrameExtractionError.failed(
+        "Could not create a temporary frame directory: \(error.localizedDescription)"
+      )
+    }
+    defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+    let frames = try extractFrames(
+      source: source,
+      durationSeconds: durationSeconds,
+      maxFrames: maxFrames,
+      in: temporaryDirectory
+    )
+    return VideoFrames(durationSeconds: durationSeconds, frames: frames)
+  }
+
+  private func duration(of source: String) throws -> Double {
+    let result = try run(
+      ffprobe,
+      arguments: [
+        "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        source,
+      ]
+    )
+    guard result.status == 0 else {
+      throw FFmpegFrameExtractionError.failed(
+        result.error.isEmpty ? "ffprobe could not read the video." : result.error
+      )
+    }
+    guard
+      let duration = Double(result.output.trimmingCharacters(in: .whitespacesAndNewlines)),
+      duration.isFinite,
+      duration > 0
+    else {
+      throw FFmpegFrameExtractionError.failed("ffprobe did not return a valid duration.")
+    }
+    return duration
+  }
+
+  private func extractFrames(
+    source: String,
+    durationSeconds: Double,
+    maxFrames: Int,
+    in temporaryDirectory: URL
+  ) throws -> [VideoFrame] {
+    let bucketDuration = durationSeconds / Double(maxFrames)
+    let frameRate = Double(maxFrames) / durationSeconds
+    let outputPattern = temporaryDirectory.appendingPathComponent("frame-%03d.jpg").path
+    let result = try run(
+      ffmpeg,
+      arguments: [
+        "-hide_banner", "-loglevel", "error",
+        "-ss", String(bucketDuration / 2),
+        "-i", source,
+        "-an", "-sn", "-dn",
+        "-vf",
+        "fps=fps=\(frameRate):round=near:eof_action=pass,scale='min(1280,iw)':'min(1280,ih)':force_original_aspect_ratio=decrease",
+        "-frames:v", String(maxFrames),
+        "-q:v", "3",
+        "-y", outputPattern,
+      ]
+    )
+    guard result.status == 0 else {
+      throw FFmpegFrameExtractionError.failed(
+        result.error.isEmpty ? "ffmpeg could not decode a frame." : result.error
+      )
+    }
+    var frames: [VideoFrame] = []
+    for index in 0..<maxFrames {
+      let filename = String(format: "frame-%03d.jpg", index + 1)
+      let outputURL = temporaryDirectory.appendingPathComponent(filename)
+      guard FileManager.default.fileExists(atPath: outputURL.path) else {
+        break
+      }
+      guard
+        let imageSource = CGImageSourceCreateWithURL(outputURL as CFURL, nil),
+        let image = CGImageSourceCreateImageAtIndex(
+          imageSource,
+          0,
+          [kCGImageSourceShouldCacheImmediately: true] as CFDictionary
+        ),
+        image.width > 0,
+        image.height > 0
+      else {
+        continue
+      }
+      frames.append(
+        VideoFrame(
+          image: image,
+          timestampSeconds: (Double(index) + 0.5) * bucketDuration
+        ))
+    }
+    guard !frames.isEmpty else {
+      throw FFmpegFrameExtractionError.failed("ffmpeg did not produce any decodable frames.")
+    }
+    return frames
+  }
+
+  private func run(_ executable: URL, arguments: [String]) throws -> ProcessResult {
+    let process = Process()
+    let output = Pipe()
+    let error = Pipe()
+    process.executableURL = executable
+    process.arguments = arguments
+    process.standardOutput = output
+    process.standardError = error
+    do {
+      try process.run()
+    } catch {
+      throw FFmpegFrameExtractionError.failed(
+        "Could not run \(executable.lastPathComponent): \(error.localizedDescription)"
+      )
+    }
+    process.waitUntilExit()
+    return ProcessResult(
+      status: process.terminationStatus,
+      output: String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
+        ?? "",
+      error: String(data: error.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    )
+  }
+
+  private static func executable(named name: String) -> URL? {
+    let path = ProcessInfo.processInfo.environment["PATH"] ?? ""
+    for directory in path.split(separator: ":", omittingEmptySubsequences: false) {
+      let directoryPath =
+        directory.isEmpty ? FileManager.default.currentDirectoryPath : String(directory)
+      let candidate = URL(fileURLWithPath: directoryPath).appendingPathComponent(name)
+      if FileManager.default.isExecutableFile(atPath: candidate.path) {
+        return candidate
+      }
+    }
+    return nil
+  }
+
+  private struct ProcessResult {
+    let status: Int32
+    let output: String
+    let error: String
+  }
+}

--- a/Sources/seev/MediaInput.swift
+++ b/Sources/seev/MediaInput.swift
@@ -95,6 +95,28 @@ func isVideoInput(_ input: String) -> Bool {
 
 @available(macOS 13.0, *)
 func extractVideoFrames(input: String, maxFrames: Int) async throws -> VideoFrames {
+  do {
+    return try await extractVideoFramesWithAVFoundation(input: input, maxFrames: maxFrames)
+  } catch {
+    do {
+      return try FFmpegFrameExtractor().extract(input: input, maxFrames: maxFrames)
+    } catch FFmpegFrameExtractionError.unavailable {
+      throw VideoInputError.invalidVideo(
+        "AVFoundation could not open the video, and ffmpeg is unavailable. Install it with 'brew install ffmpeg'."
+      )
+    } catch {
+      throw VideoInputError.invalidVideo(
+        "AVFoundation could not open the video, and the ffmpeg fallback failed: \(error.localizedDescription)"
+      )
+    }
+  }
+}
+
+@available(macOS 13.0, *)
+private func extractVideoFramesWithAVFoundation(
+  input: String,
+  maxFrames: Int
+) async throws -> VideoFrames {
   let asset = AVURLAsset(url: inputImagePathToURL(input))
   let duration: CMTime
   let tracks: [AVAssetTrack]

--- a/Sources/seev/seev.swift
+++ b/Sources/seev/seev.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-let VERSION = "2.4.0"
+let VERSION = "2.5.0"
 
 private func positiveInteger(_ argument: String) throws -> Int {
   guard let value = Int(argument), value > 0 else {


### PR DESCRIPTION
## Summary

- fall back to ffprobe and ffmpeg when AVFoundation cannot open a video
- extract at most --max-frames representative JPEGs in a unique temporary directory
- load frames into memory and remove temporary files before analysis
- document optional ffmpeg support for WebM and bump seeV to 2.5.0

## Validation

- release build passes
- both supplied VP8 WebM files work with standalone Vision commands, most, nsfw, and all
- native MP4 decoding works without ffmpeg on PATH
- bundled still-image analysis remains unchanged
- missing ffmpeg produces an actionable installation error
- temporary frame directories are cleaned up